### PR TITLE
add fast node config

### DIFF
--- a/cmd/terrad/config.go
+++ b/cmd/terrad/config.go
@@ -34,6 +34,12 @@ func initAppConfig() (string, interface{}) {
 	// In simapp, we set the min gas prices to 0.
 	srvCfg.MinGasPrices = "0uluna"
 
+	// This ensures that Terra upgrades will use IAVL fast node.
+	// There's a second order effect: archive nodes will take a veritable long-ass time to upgrade.
+	// Reference this history of this file for more information: https://github.com/evmos/evmos/blob/1ca54a4e1c0812933960a9c943a7ab6c4901210d/cmd/evmosd/root.go
+
+	srvCfg.IAVLDisableFastNode = false
+
 	terraAppConfig := TerraAppConfig{
 		Config:     *srvCfg,
 		WASMConfig: *wasmconfig.DefaultConfig(),


### PR DESCRIPTION
## Summary of changes

This PR:

* locks fast node in root.go -- all nodes will use fast node
* Adds a pruning flag
* Adds a vestigial flag that no one should use ever that disables fast node (this is sadly necessary for the config to work)



## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
