### PR TITLE
Replace gofmt with gofumpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ benchmark:
 ###############################################################################
 
 lint:
-	sudo golangci-lint run --out-format=tab
+	golangci-lint run --out-format=tab
 
 lint-fix:
 	golangci-lint run --fix --out-format=tab --issues-exit-code=0

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ benchmark:
 ###############################################################################
 
 lint:
-	golangci-lint run --out-format=tab
+	sudo golangci-lint run --out-format=tab
 
 lint-fix:
 	golangci-lint run --fix --out-format=tab --issues-exit-code=0

--- a/Makefile
+++ b/Makefile
@@ -197,16 +197,16 @@ benchmark:
 ###############################################################################
 
 lint:
-	sudo golangci-lint run --out-format=tab
+	golangci-lint run --out-format=tab
 
 lint-fix:
 	golangci-lint run --fix --out-format=tab --issues-exit-code=0
 .PHONY: lint lint-fix
 
 format:
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs gofmt -w -s
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs misspell -w
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' -not -name '*.pb.gw.go' | xargs gofumpt -w
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' -not -name '*.pb.gw.go' | xargs misspell -w
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' -not -name '*.pb.gw.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
 .PHONY: format
 
 ###############################################################################

--- a/custom/auth/ante/burntax.go
+++ b/custom/auth/ante/burntax.go
@@ -1,10 +1,11 @@
 package ante
 
 import (
+	treasury "github.com/terra-money/core/x/treasury/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	treasury "github.com/terra-money/core/x/treasury/types"
 )
 
 // TaxPowerUpgradeHeight is when taxes are allowed to go into effect

--- a/custom/auth/ante/burntax_test.go
+++ b/custom/auth/ante/burntax_test.go
@@ -6,11 +6,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
+	"github.com/terra-money/core/custom/auth/ante"
+	core "github.com/terra-money/core/types"
+
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	"github.com/terra-money/core/custom/auth/ante"
-	core "github.com/terra-money/core/types"
 )
 
 func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {

--- a/x/wasm/types/expected_keeper.go
+++ b/x/wasm/types/expected_keeper.go
@@ -1,13 +1,14 @@
 package types
 
 import (
+	connectiontypes "github.com/cosmos/ibc-go/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/modules/core/exported"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
-	connectiontypes "github.com/cosmos/ibc-go/modules/core/03-connection/types"
-	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
-	ibcexported "github.com/cosmos/ibc-go/modules/core/exported"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )


### PR DESCRIPTION
## Summary of changes

Maintain consistency with @faddat commits on code formatting by changing the command use by `make format` from `gofmt` to `gofumpt`.

Also, when formatting, ignore files that match `*.pb.gw.go`.

- https://github.com/terra-rebels/classic/commit/6fa068c9634ea8f9198c9fd56965c29c93a84145

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
