### PR TITLE
Fix: DefaultGasMultiplier was accidentally applied twice for humanizeCost and canonicalizeCost

### DIFF
--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -8,12 +8,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/terra-money/core/x/wasm/types"
+
 )
 
 func (k Keeper) getCosmWasmAPI(ctx sdk.Context) cosmwasm.GoAPI {
 	return cosmwasm.GoAPI{
 		HumanAddress: func(canon []byte) (humanAddr string, usedGas uint64, err error) {
-			humanizeCost := types.HumanizeWasmGasCost * types.GasMultiplier
+			humanizeCost := types.HumanizeWasmGasCost
 			err = sdk.VerifyAddressFormat(canon)
 			if err != nil {
 				return "", humanizeCost, nil
@@ -22,7 +23,7 @@ func (k Keeper) getCosmWasmAPI(ctx sdk.Context) cosmwasm.GoAPI {
 			return sdk.AccAddress(canon).String(), humanizeCost, nil
 		},
 		CanonicalAddress: func(human string) (canonicalAddr []byte, usedGas uint64, err error) {
-			canonicalizeCost := types.CanonicalizeWasmGasCost * types.GasMultiplier
+			canonicalizeCost := types.CanonicalizeWasmGasCost
 			addr, err := sdk.AccAddressFromBech32(human)
 			if err != nil {
 				return nil, canonicalizeCost, err


### PR DESCRIPTION
the humanize and canonicalize API functions in x/wasm/keeper/api.go should return consumed wasmVMGas = sdkGas * DefaultGasMultiplier. The DefaultGasMultiplier was accidentally applied twice ( because pre-multiplied in x/wasm/keeper/gas_meter.go).

For the time being this does not cause too much of an error, as  the multiplier is currently 100. In future versions of wasmVM the multiplier is going to increase tremendously (by factor 140,000), causing contracts to consistently run out of gas on instantiate.