### PR TITLE
Do not charge taxes on ibc assets

### DIFF
--- a/custom/auth/ante/burntax_test.go
+++ b/custom/auth/ante/burntax_test.go
@@ -25,7 +25,7 @@ func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {
 	priv1, _, addr1 := testdata.KeyTestPubAddr()
 
 	// msg and signatures
-	sendAmount := int64(1000000)
+	sendAmount := int64(1_000_000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
 	msg := banktypes.NewMsgSend(addr1, addr1, sendCoins)
 
@@ -50,7 +50,8 @@ func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {
 	suite.Require().NoError(err, "Decorator should not have errored when block height is 1")
 
 	// Set the blockheight past the tax height block
-	suite.ctx = suite.ctx.WithBlockHeight(10000000)
+	suite.ctx = suite.ctx.WithBlockHeight(10_000_000)
+
 	// antehandler errors with insufficient fees due to tax
 	_, err = antehandler(suite.ctx, tx, false)
 	suite.Require().Error(err, "Decorator should errored on low fee for local gasPrice + tax")
@@ -86,4 +87,47 @@ func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {
 
 	// Total supply should have decreased by the tax amount
 	suite.Require().Equal(taxes, totalSupply.Sub(supplyAfterBurn))
+}
+
+func (suite *AnteTestSuite) TestEnsureIBCUntaxed() {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewBurnTaxFeeDecorator(suite.app.TreasuryKeeper, suite.app.BankKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+
+	// msg and signatures
+	sendAmount := int64(1_000_000)
+	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.OsmoIbcDenom, sendAmount))
+	msg := banktypes.NewMsgSend(addr1, addr1, sendCoins)
+
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msg))
+	suite.txBuilder.SetFeeAmount(feeAmount)
+	suite.txBuilder.SetGasLimit(gasLimit)
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	// set zero gas prices
+	suite.ctx = suite.ctx.WithMinGasPrices(sdk.NewDecCoins())
+
+	// Set IsCheckTx to true
+	suite.ctx = suite.ctx.WithIsCheckTx(true)
+
+	// IBC must pass without burn before the specified tax block height
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().NoError(err, "Decorator should not have errored on IBC denoms when block height is 1")
+
+	// Set the blockheight past the tax height block
+	suite.ctx = suite.ctx.WithBlockHeight(10_000_000)
+
+	// IBC must pass without burn after the specified tax block height
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().NoError(err, "Decorator should not have errored on IBC denoms when block height is 10,000,000")
 }

--- a/custom/auth/ante/tax.go
+++ b/custom/auth/ante/tax.go
@@ -2,6 +2,8 @@ package ante
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -16,6 +18,9 @@ import (
 
 // MaxOracleMsgGasUsage is constant expected oracle msg gas cost
 const MaxOracleMsgGasUsage = uint64(100_000)
+
+// compile on package import
+var IBCRegexp = regexp.MustCompile("^ibc/[a-fA-F0-9]{64}$")
 
 // TaxFeeDecorator will check if the transaction's fee is at least as large
 // as tax + the local validator's minimum gasFee (defined in validator config)
@@ -142,6 +147,10 @@ func FilterMsgAndComputeTax(ctx sdk.Context, tk TreasuryKeeper, msgs ...sdk.Msg)
 	return taxes
 }
 
+func isIBCDenom(denom string) bool {
+	return IBCRegexp.MatchString(strings.ToLower(denom))
+}
+
 // computes the stability tax according to tax-rate and tax-cap
 func computeTax(ctx sdk.Context, tk TreasuryKeeper, principal sdk.Coins) sdk.Coins {
 	currHeight := ctx.BlockHeight()
@@ -157,6 +166,9 @@ func computeTax(ctx sdk.Context, tk TreasuryKeeper, principal sdk.Coins) sdk.Coi
 			continue
 		}
 		if coin.Denom == sdk.DefaultBondDenom {
+			continue
+		}
+		if isIBCDenom(coin.Denom) {
 			continue
 		}
 

--- a/types/alias.go
+++ b/types/alias.go
@@ -40,6 +40,7 @@ const (
 	BombayChainID         = "bombay-12"
 	SwapDisableForkHeight = fork.SwapDisableForkHeight
 	SwapEnableForkHeight  = fork.SwapEnableForkHeight
+	OsmoIbcDenom          = "ibc/0ef15df2f02480ade0bb6e85d9ebb5daea2836d3860e9f97f9aade4f57a31aa0"
 )
 
 // functions aliases


### PR DESCRIPTION
## Summary of changes

I feel like IBC assets should by no means charged with on-chain taxes. The original [proposal](https://classic-agora.terra.money/t/burn-mechanism-on-transactions-1-2/43759) from VegasMorph is actually not very specific about it. But it clearly sees taxes as an instrument to reduce the LUNC supply (not the supply of off-chain assets).

This PR excludes IBC assets from being charged with taxes. Changes include:

    add test to verify IBC assets are not charged with taxes
    filter out IBC denoms from the list of taxable denoms

Another path of implementation would have been to create a whitelist of taxable assets. I purposely excluded only the IBC denoms - because I felt this might be right (please, proof me wrong). And I also did not want to tinker to much with the tax implementation.

This is follow-up of PR #33. I messed everything up. So I had to rebase and force push. This is ugly :(

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
