### PR TITLE
Add pebbledb support (Rework of Makefiles)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))
   build_tags += boltdb
 endif
 
+ifeq (pebbledb,$(findstring pebbledb,$(COSMOS_BUILD_OPTIONS)))
+  build_tags += pebbledb
+endif
+
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
@@ -87,6 +91,10 @@ endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
+endif
+# handle pebbledb
+ifeq (pebbledb,$(findstring pebbledb,$(COSMOS_BUILD_OPTIONS)))
+  ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
 endif
 
 ifeq (,$(findstring nostrip,$(COSMOS_BUILD_OPTIONS)))

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	// tendermint with terra oracle support
 	github.com/tendermint/tendermint => github.com/terra-money/tendermint v0.34.14-terra.2
-	// tm-db with pebbledb support so that things can go fast
+	// use notionals tm-db
 	github.com/tendermint/tm-db => github.com/baabeetaa/tm-db v0.6.7-0.20220827003937-31989c12be6f
 	// enforce the use of grpc v1.33.2, which is compatible with the cosmos flavored protocol buffers
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2


### PR DESCRIPTION
## Summary of changes

In the making of this PR I noticed that PebbleDB support was already added earlier by @faddat (using replace statement in go.mod). See [here](https://github.com/baabeetaa/tm-db). Therefore the actual diff remains adding pebbledb as `COSMOS_BUILD_OPTION`. Build & install with `COSMOS_BUILD_OPTIONS=pebbledb make install`. We should make pebbledb the default option.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]
- [ ] Make pebbledb the standard backend db

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
